### PR TITLE
Schedule and Run commands

### DIFF
--- a/protocol/Cargo.lock
+++ b/protocol/Cargo.lock
@@ -167,7 +167,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 [[package]]
 name = "wasmdome-domain"
 version = "0.0.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "eventsourcing 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "eventsourcing-derive 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -178,13 +177,13 @@ dependencies = [
 
 [[package]]
 name = "wasmdome-protocol"
-version = "0.0.9"
+version = "0.0.10"
 dependencies = [
  "chrono 0.4.13 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.104 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_derive 1.0.104 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_json 1.0.48 (registry+https://github.com/rust-lang/crates.io-index)",
- "wasmdome-domain 0.0.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "wasmdome-domain 0.0.6",
 ]
 
 [[package]]
@@ -228,7 +227,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum time 0.1.43 (registry+https://github.com/rust-lang/crates.io-index)" = "ca8a50ef2360fbd1eeb0ecd46795a87a19024eb4b53c5dc916ca1fd95fe62438"
 "checksum unicode-xid 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "fc72304796d0818e357ead4e000d19c9c174ab23dc11093ac919054d20a6a7fc"
 "checksum unicode-xid 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "826e7639553986605ec5979c7dd957c7895e93eabed50ab2ffa7f6128a75097c"
-"checksum wasmdome-domain 0.0.6 (registry+https://github.com/rust-lang/crates.io-index)" = "9b9f400b79b2c4a8abdb6a2d87d99bce22caf79f78d7b1c35fc62e5cba21a3b1"
 "checksum winapi 0.3.8 (registry+https://github.com/rust-lang/crates.io-index)" = "8093091eeb260906a183e6ae1abdba2ef5ef2257a21801128899c3fc699229c6"
 "checksum winapi-i686-pc-windows-gnu 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
 "checksum winapi-x86_64-pc-windows-gnu 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"

--- a/protocol/Cargo.lock
+++ b/protocol/Cargo.lock
@@ -177,7 +177,7 @@ dependencies = [
 
 [[package]]
 name = "wasmdome-protocol"
-version = "0.0.10"
+version = "0.0.11"
 dependencies = [
  "chrono 0.4.13 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.104 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/protocol/Cargo.toml
+++ b/protocol/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wasmdome-protocol"
-version = "0.0.10"
+version = "0.0.11"
 authors = ["Kevin Hoffman <alothien@gmail.com>"]
 edition = "2018"
 homepage = "https://wasmdome.dev"

--- a/protocol/Cargo.toml
+++ b/protocol/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wasmdome-protocol"
-version = "0.0.9"
+version = "0.0.10"
 authors = ["Kevin Hoffman <alothien@gmail.com>"]
 edition = "2018"
 homepage = "https://wasmdome.dev"
@@ -16,5 +16,5 @@ categories = ["wasm", "games"]
 serde = "1.0"
 serde_derive = "1.0"
 serde_json = "1.0"
-wasmdome-domain = "0.0.6"
+wasmdome-domain = { path = "../domaincommon" }
 chrono = { version = "0.4.13", features = ["serde"] }

--- a/protocol/src/lib.rs
+++ b/protocol/src/lib.rs
@@ -131,3 +131,29 @@ pub mod tools {
         Error(String),
     }
 }
+
+pub mod scheduler {
+    use chrono::DateTime;
+    use chrono::Utc;
+
+    #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+    pub struct MatchScheduleEntry {
+        pub max_actors: u32,
+        pub board_height: u32,
+        pub board_width: u32,
+        pub max_turns: u32,
+        pub match_start: DateTime<Utc>,
+    }
+
+    #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+    pub struct MatchIdentifier {
+        pub match_id: String,
+    }
+
+    #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+    pub struct StoredMatch {
+        pub match_id: String,
+        pub entry: MatchScheduleEntry,
+        pub aps_per_turn: u32,
+    }
+}

--- a/scheduler/Cargo.lock
+++ b/scheduler/Cargo.lock
@@ -20,9 +20,9 @@ checksum = "4785bdd1c96b2a846b2bd7cc02e86b6b3dbf14e7e53446c4f54c92a361040822"
 
 [[package]]
 name = "chrono"
-version = "0.4.12"
+version = "0.4.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f0fee792e164f78f5fe0c296cc2eb3688a2ca2b70cdff33040922d298203f0c4"
+checksum = "c74d84029116787153e02106bf53e66828452a4b325cc8652b788b5967c0a0b6"
 dependencies = [
  "num-integer",
  "num-traits",
@@ -164,7 +164,7 @@ checksum = "71d301d4193d031abdd79ff7e3dd721168a9572ef3fe51a1517aba235bd8f86e"
 
 [[package]]
 name = "scheduler"
-version = "0.0.1"
+version = "0.0.2"
 dependencies = [
  "chrono",
  "log",
@@ -295,9 +295,7 @@ dependencies = [
 
 [[package]]
 name = "wasmdome-domain"
-version = "0.0.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c51abe3ca8a749222324d783a5b320834d3741a87d29f7fa7a361f468b8da12d"
+version = "0.0.6"
 dependencies = [
  "eventsourcing",
  "eventsourcing-derive",
@@ -308,9 +306,7 @@ dependencies = [
 
 [[package]]
 name = "wasmdome-protocol"
-version = "0.0.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "17fe2ce4bdbab3c52aaf9311627128aa462614587e4c33d81c5812f534f7fd01"
+version = "0.0.10"
 dependencies = [
  "chrono",
  "serde",

--- a/scheduler/Cargo.toml
+++ b/scheduler/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "scheduler"
-version = "0.0.1"
+version = "0.0.2"
 authors = ["Kevin Hoffman <alothien@gmail.com>"]
 edition = "2018"
 
@@ -9,7 +9,7 @@ crate-type = ["cdylib"]
 
 [dependencies]
 wascc-actor = "0.7.2"
-wasmdome-protocol = "0.0.6"
+wasmdome-protocol = { path = "../protocol" }
 chrono = { version = "0.4.11", features = ["serde"] }
 serde = { version = "1.0.114", features = ["derive"]}
 serde_json = "1.0.56"

--- a/scheduler/src/lib.rs
+++ b/scheduler/src/lib.rs
@@ -20,6 +20,9 @@ extern crate log;
 
 extern crate wascc_actor as actor;
 
+extern crate wasmdome_protocol as protocol;
+use protocol::scheduler::*;
+
 const SUBJECT_REQUEST_SCHEDULE: &str = "wasmdome.public.arena.schedule";
 const SUBJECT_ADD_MATCH: &str = "wasmdome.internal.arena.new_match";
 const SUBJECT_DEL_MATCH: &str = "wasmdome.internal.arena.del_match";
@@ -27,8 +30,6 @@ const SUBJECT_DEL_MATCH: &str = "wasmdome.internal.arena.del_match";
 const APS_PER_TURN: u32 = 4;
 
 use actor::prelude::*;
-use chrono::DateTime;
-use chrono::Utc;
 
 actor_handlers! {
     codec::messaging::OP_DELIVER_MESSAGE => handle_message,
@@ -98,25 +99,4 @@ fn match_key(match_id: &str) -> String {
 
 fn match_set_key() -> String {
     "wasmdome:sched_matches".to_string()
-}
-
-#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
-struct MatchScheduleEntry {
-    pub max_actors: u32,
-    pub board_height: u32,
-    pub board_width: u32,
-    pub max_turns: u32,
-    pub match_start: DateTime<Utc>,
-}
-
-#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
-struct MatchIdentifier {
-    pub match_id: String,
-}
-
-#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
-struct StoredMatch {
-    match_id: String,
-    entry: MatchScheduleEntry,
-    aps_per_turn: u32,
 }

--- a/wasmdome/Cargo.lock
+++ b/wasmdome/Cargo.lock
@@ -1943,6 +1943,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "uuid"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9fde2f6a4bea1d6e007c4ad38c6839fa71cbb63b6dbf5b595aa38dc9b1093c11"
+dependencies = [
+ "rand 0.7.3",
+]
+
+[[package]]
 name = "vcpkg"
 version = "0.2.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2064,26 +2073,14 @@ dependencies = [
  "serde",
  "serde_json",
  "structopt 0.3.15",
- "wasmdome-domain 0.0.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "uuid",
+ "wasmdome-domain",
  "wasmdome-protocol",
 ]
 
 [[package]]
 name = "wasmdome-domain"
 version = "0.0.6"
-dependencies = [
- "eventsourcing",
- "eventsourcing-derive",
- "serde",
- "serde_derive",
- "serde_json",
-]
-
-[[package]]
-name = "wasmdome-domain"
-version = "0.0.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9b9f400b79b2c4a8abdb6a2d87d99bce22caf79f78d7b1c35fc62e5cba21a3b1"
 dependencies = [
  "eventsourcing",
  "eventsourcing-derive",
@@ -2100,7 +2097,7 @@ dependencies = [
  "serde",
  "serde_derive",
  "serde_json",
- "wasmdome-domain 0.0.6",
+ "wasmdome-domain",
 ]
 
 [[package]]

--- a/wasmdome/Cargo.lock
+++ b/wasmdome/Cargo.lock
@@ -350,6 +350,20 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b3a71ab494c0b5b860bdc8407ae08978052417070c2ced38573a9157ad75b8ac"
 
 [[package]]
+name = "crossbeam"
+version = "0.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "69323bff1fb41c635347b8ead484a5ca6c3f11914d784170b158d8449ab07f8e"
+dependencies = [
+ "cfg-if",
+ "crossbeam-channel",
+ "crossbeam-deque",
+ "crossbeam-epoch",
+ "crossbeam-queue",
+ "crossbeam-utils",
+]
+
+[[package]]
 name = "crossbeam-channel"
 version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2063,6 +2077,7 @@ name = "wasmdome"
 version = "0.0.4"
 dependencies = [
  "chrono",
+ "crossbeam",
  "crossbeam-channel",
  "dirs 3.0.0",
  "env_logger 0.7.1",

--- a/wasmdome/Cargo.lock
+++ b/wasmdome/Cargo.lock
@@ -2060,7 +2060,7 @@ checksum = "7f7b90ea6c632dd06fd765d44542e234d5e63d9bb917ecd64d79778a13bd79ae"
 
 [[package]]
 name = "wasmdome"
-version = "0.0.3"
+version = "0.0.4"
 dependencies = [
  "chrono",
  "crossbeam-channel",
@@ -2080,7 +2080,7 @@ dependencies = [
 
 [[package]]
 name = "wasmdome-domain"
-version = "0.0.6"
+version = "0.0.7"
 dependencies = [
  "eventsourcing",
  "eventsourcing-derive",
@@ -2091,7 +2091,7 @@ dependencies = [
 
 [[package]]
 name = "wasmdome-protocol"
-version = "0.0.10"
+version = "0.0.11"
 dependencies = [
  "chrono",
  "serde",

--- a/wasmdome/Cargo.lock
+++ b/wasmdome/Cargo.lock
@@ -219,7 +219,10 @@ version = "0.2.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2889e6d50f394968c8bf4240dc3f2a7eb4680844d27308f798229ac9d4725f41"
 dependencies = [
+ "lazy_static",
  "memchr",
+ "regex-automata",
+ "serde",
 ]
 
 [[package]]
@@ -260,9 +263,9 @@ checksum = "b486ce3ccf7ffd79fdeb678eac06a9e6c09fc88d33836340becb8fffe87c5e33"
 
 [[package]]
 name = "chrono"
-version = "0.4.12"
+version = "0.4.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f0fee792e164f78f5fe0c296cc2eb3688a2ca2b70cdff33040922d298203f0c4"
+checksum = "c74d84029116787153e02106bf53e66828452a4b325cc8652b788b5967c0a0b6"
 dependencies = [
  "num-integer",
  "num-traits",
@@ -404,6 +407,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "csv"
+version = "1.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "00affe7f6ab566df61b4be3ce8cf16bc2576bca0963ceb0955e45d514bf9a279"
+dependencies = [
+ "bstr",
+ "csv-core",
+ "itoa",
+ "ryu",
+ "serde",
+]
+
+[[package]]
+name = "csv-core"
+version = "0.1.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2b2466559f260f48ad25fe6317b3c8dac77b5bdb5763ac7d9d6103530663bc90"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
 name = "curve25519-dalek"
 version = "1.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -429,6 +454,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f3d0c8c8752312f9713efd397ff63acb9f85585afbf179282e720e7704954dd5"
 dependencies = [
  "generic-array",
+]
+
+[[package]]
+name = "dirs"
+version = "1.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3fd78930633bd1c6e35c4b42b1df7b0cbc6bc191146e512bb3bedf243fcc3901"
+dependencies = [
+ "libc",
+ "redox_users",
+ "winapi",
 ]
 
 [[package]]
@@ -480,6 +516,12 @@ name = "either"
 version = "1.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bb1f6b1ce1c140482ea30ddd3335fc0024ac7ee112895426e0a629a6c20adfe3"
+
+[[package]]
+name = "encode_unicode"
+version = "0.3.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a357d28ed41a50f9c765dbfe56cbc04a64e53e5fc58ba79fbc34c10ef3df831f"
 
 [[package]]
 name = "env_logger"
@@ -1065,6 +1107,20 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "74490b50b9fbe561ac330df47c08f3f33073d2d00c150f719147d7c54522fa1b"
 
 [[package]]
+name = "prettytable-rs"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0fd04b170004fa2daccf418a7f8253aaf033c27760b5f225889024cf66d7ac2e"
+dependencies = [
+ "atty",
+ "csv",
+ "encode_unicode",
+ "lazy_static",
+ "term",
+ "unicode-width",
+]
+
+[[package]]
 name = "proc-macro-error"
 version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1387,6 +1443,15 @@ dependencies = [
  "memchr",
  "regex-syntax",
  "thread_local",
+]
+
+[[package]]
+name = "regex-automata"
+version = "0.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ae1ded71d66a4a97f5e961fd0cb25a5f366a42a41570d16a763a69c092c26ae4"
+dependencies = [
+ "byteorder",
 ]
 
 [[package]]
@@ -1751,6 +1816,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "term"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "edd106a334b7657c10b7c540a0106114feadeb4dc314513e97df481d5d966f42"
+dependencies = [
+ "byteorder",
+ "dirs 1.0.5",
+ "winapi",
+]
+
+[[package]]
 name = "termcolor"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1977,24 +2053,37 @@ checksum = "7f7b90ea6c632dd06fd765d44542e234d5e63d9bb917ecd64d79778a13bd79ae"
 name = "wasmdome"
 version = "0.0.3"
 dependencies = [
+ "chrono",
  "crossbeam-channel",
- "dirs",
+ "dirs 3.0.0",
  "env_logger 0.7.1",
  "nats",
  "nkeys",
+ "prettytable-rs",
  "quicli",
  "serde",
  "serde_json",
  "structopt 0.3.15",
- "wasmdome-domain",
+ "wasmdome-domain 0.0.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "wasmdome-protocol",
 ]
 
 [[package]]
 name = "wasmdome-domain"
-version = "0.0.4"
+version = "0.0.6"
+dependencies = [
+ "eventsourcing",
+ "eventsourcing-derive",
+ "serde",
+ "serde_derive",
+ "serde_json",
+]
+
+[[package]]
+name = "wasmdome-domain"
+version = "0.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c51abe3ca8a749222324d783a5b320834d3741a87d29f7fa7a361f468b8da12d"
+checksum = "9b9f400b79b2c4a8abdb6a2d87d99bce22caf79f78d7b1c35fc62e5cba21a3b1"
 dependencies = [
  "eventsourcing",
  "eventsourcing-derive",
@@ -2005,15 +2094,13 @@ dependencies = [
 
 [[package]]
 name = "wasmdome-protocol"
-version = "0.0.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "17fe2ce4bdbab3c52aaf9311627128aa462614587e4c33d81c5812f534f7fd01"
+version = "0.0.10"
 dependencies = [
  "chrono",
  "serde",
  "serde_derive",
  "serde_json",
- "wasmdome-domain",
+ "wasmdome-domain 0.0.6",
 ]
 
 [[package]]

--- a/wasmdome/Cargo.toml
+++ b/wasmdome/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wasmdome"
-version = "0.0.3"
+version = "0.0.4"
 authors = ["Kevin Hoffman <alothien@gmail.com>"]
 edition = "2018"
 

--- a/wasmdome/Cargo.toml
+++ b/wasmdome/Cargo.toml
@@ -15,8 +15,9 @@ quicli = "0.4.0"
 structopt = "0.3.15"
 nats = "0.6.0"
 wasmdome-protocol = { path = "../protocol" }
-wasmdome-domain = "0.0.6"
+wasmdome-domain = { path = "../domaincommon" }
 dirs = "3.0.0"
 prettytable-rs = "0.8"
+uuid = { version = "0.8", features = ["v4"] }
 
 chrono = { version = "0.4.13", features = ["serde"] }

--- a/wasmdome/Cargo.toml
+++ b/wasmdome/Cargo.toml
@@ -14,6 +14,9 @@ env_logger = "0.7.1"
 quicli = "0.4.0"
 structopt = "0.3.15"
 nats = "0.6.0"
-wasmdome-protocol = "0.0.6"
-wasmdome-domain = "0.0.4"
+wasmdome-protocol = { path = "../protocol" }
+wasmdome-domain = "0.0.6"
 dirs = "3.0.0"
+prettytable-rs = "0.8"
+
+chrono = { version = "0.4.13", features = ["serde"] }

--- a/wasmdome/Cargo.toml
+++ b/wasmdome/Cargo.toml
@@ -19,5 +19,5 @@ wasmdome-domain = { path = "../domaincommon" }
 dirs = "3.0.0"
 prettytable-rs = "0.8"
 uuid = { version = "0.8", features = ["v4"] }
-
+crossbeam = "0.7.3"
 chrono = { version = "0.4.13", features = ["serde"] }

--- a/wasmdome/src/main.rs
+++ b/wasmdome/src/main.rs
@@ -53,10 +53,6 @@ enum WasmdomeAction {
         #[structopt(short = "t", long = "max_turns")]
         max_turns: u32,
 
-        /// Maximum number of actors in the match
-        #[structopt(short = "a", long = "max_actors")]
-        max_actors: u32,
-
         /// Board height
         #[structopt(short = "h", long = "height")]
         board_height: u32,
@@ -78,18 +74,10 @@ fn handle_command(cmd: CliCommand) -> std::result::Result<(), Box<dyn ::std::err
         WasmdomeAction::Schedule { .. } => check_schedule(nc)?,
         WasmdomeAction::Run {
             max_turns,
-            max_actors,
             board_height,
             board_width,
             aps_per_turn,
-        } => run_match(
-            nc,
-            max_turns,
-            max_actors,
-            board_height,
-            board_width,
-            aps_per_turn,
-        )?,
+        } => run_match(nc, max_turns, board_height, board_width, aps_per_turn)?,
     };
     Ok(())
 }
@@ -198,7 +186,6 @@ fn check_schedule(nc: nats::Connection) -> Result<(), Box<dyn Error>> {
 fn run_match(
     nc: nats::Connection,
     max_turns: u32,
-    max_actors: u32,
     board_height: u32,
     board_width: u32,
     aps_per_turn: u32,
@@ -232,12 +219,7 @@ fn run_match(
 
     let cm = StartMatch(CreateMatch {
         match_id: match_id.clone(),
-        actors: res
-            .mechs
-            .iter()
-            .map(|m| m.id.clone())
-            .take(max_actors as usize)
-            .collect(),
+        actors: res.mechs.iter().map(|m| m.id.clone()).collect(),
         board_height,
         board_width,
         max_turns,

--- a/wasmdome/src/main.rs
+++ b/wasmdome/src/main.rs
@@ -173,7 +173,11 @@ fn run_match(
         Ok(())
     });
 
-    println!("{}", r.recv().unwrap());
+    println!(
+        "{}",
+        r.recv_timeout(std::time::Duration::from_millis(5000))
+            .unwrap_or("Timeout occurred retrieving game results.".to_string())
+    );
 
     Ok(())
 }

--- a/wasmdome/src/main.rs
+++ b/wasmdome/src/main.rs
@@ -1,9 +1,13 @@
 extern crate wasmdome_protocol as protocol;
 
+use protocol::scheduler::StoredMatch;
 use protocol::tools::{CredentialsRequest, CredentialsResponse};
-use std::{collections::HashMap, error::Error, path::PathBuf, time::Duration};
+use std::{error::Error, path::PathBuf, time::Duration};
 use structopt::clap::AppSettings;
 use structopt::StructOpt;
+#[macro_use]
+extern crate prettytable;
+use prettytable::Table;
 
 #[derive(Debug, StructOpt, Clone)]
 #[structopt(
@@ -30,18 +34,46 @@ enum WasmdomeAction {
     /// Configure local credentials to compete in the arena by submitting an access token
     Compete {
         /// Your account public key
+        #[structopt(short = "a", long = "account")]
         account: String,
 
         /// Short-lived access token granted by the wasmdome.dev website
+        #[structopt(short = "t", long = "token")]
         token: String,
+    },
+    /// Query the schedule of upcoming matches
+    Schedule {},
+    /// Run a wasmdome match using the local lattice
+    Run {
+        /// Maximum number of turns in the match
+        #[structopt(short = "t", long = "max_turns")]
+        max_turns: u32,
+
+        /// Maximum number of actors in the match
+        #[structopt(short = "a", long = "max_actors")]
+        max_actors: u32,
+
+        /// Board height
+        #[structopt(short = "h", long = "height")]
+        height: u32,
+
+        /// Board width
+        #[structopt(short = "w", long = "width")]
+        width: u32,
     },
 }
 
 fn handle_command(cmd: CliCommand) -> std::result::Result<(), Box<dyn ::std::error::Error>> {
     let nc = nats::connect("127.0.0.1")?; // Connect to the leaf node on loopback
-    println!("{:?}", cmd);
     match cmd.action {
         WasmdomeAction::Compete { token, account } => change_compete_creds(nc, &account, &token)?,
+        WasmdomeAction::Schedule { .. } => check_schedule(nc)?,
+        WasmdomeAction::Run {
+            max_turns,
+            max_actors,
+            height,
+            width,
+        } => run_match(nc, max_turns, max_actors, height, width)?,
     };
     Ok(())
 }
@@ -102,6 +134,71 @@ NKEYs are sensitive and should be treated as secrets.
     } else {
         Err("Did not obtain valid arena credentials".into())
     }
+}
+
+fn check_schedule(nc: nats::Connection) -> Result<(), Box<dyn Error>> {
+    let res = nc.request_timeout(
+        "wasmdome.public.arena.schedule",
+        "",
+        std::time::Duration::from_millis(500),
+    );
+
+    if let Err(e) = res {
+        println!("Error requesting schedule from the lattice: {}", e);
+        return Ok(());
+    };
+
+    let data = &res.unwrap().data;
+    let matches: Vec<StoredMatch> = serde_json::from_slice(data)?;
+    let mut table = Table::new();
+    if matches.len() > 0 {
+        table.add_row(row![
+            "Match Id",
+            "Match Start",
+            "Board Size (H ⨯ W)",
+            "Max Actors",
+            "Max Turns",
+            "Actions per turn"
+        ]);
+        matches.iter().for_each(|m| {
+            table.add_row(row![
+                format!("{}", m.match_id),
+                format!("{}", m.entry.match_start),
+                format!("{} ⨯ {}", m.entry.board_height, m.entry.board_width),
+                format!("{}", m.entry.max_actors),
+                format!("{}", m.entry.max_turns),
+                format!("{}", m.aps_per_turn),
+            ]);
+        });
+    } else {
+        println!("No schedule results available.");
+        return Ok(());
+    };
+
+    table.printstd();
+    Ok(())
+}
+
+fn run_match(
+    nc: nats::Connection,
+    max_turns: u32,
+    max_actors: u32,
+    height: u32,
+    width: u32,
+) -> Result<(), Box<dyn Error>> {
+    // publish game start command onto local lattice (through nc)
+    // let res = nc.request_timeout(
+    //     "wasmdome.public.arena.schedule",
+    //     "",
+    //     std::time::Duration::from_millis(500),
+    // );
+    // subscribe to arena events topic and then display match conclusion event, or timeout with an error
+
+    // ensure engine-provider is running
+    // ensure at least 1 mech is scheduled in the match
+    // wasmdome run -t 100 -a 20 -h 8 -w 8, turn limit, actors, height, width
+    // when do we start the match?
+    Ok(())
 }
 /*
 


### PR DESCRIPTION
Implementation of run and schedule commands for the offline wasmdome CLI.

`wasmdome schedule` returns a list of upcoming matches found by querying the local lattice. This command requires no arguments.

`wasmdome run` accepts the arguments `max_turns`, `board_height`, `board_width`, and `aps_per_turn`. It can be used to schedule a match on the local lattice, using all of the mechs that are currently available locally, and will output the result of the match after it finishes.

This update requires new crate versions of `scheduler` and `protocol`. `wasmdome` also has a version bump.